### PR TITLE
Add out-file and out-format flags to allow saving results to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0] - 2023-04-17
 ### Added
+- **New:** `Add out-format flag.` [#68](https://github.com/brittandeyoung/ckia/issues/68)
+- **New:** `Add out-file flag.` [#68](https://github.com/brittandeyoung/ckia/issues/68)
 - **New:** `Add progress bar when running checks.` [#57](https://github.com/brittandeyoung/ckia/issues/57)
 - **New Flag:** `aws check --exclude-checks` [#49](https://github.com/brittandeyoung/ckia/issues/49)
 - **New Flag:** `aws check --include-checks` [#49](https://github.com/brittandeyoung/ckia/issues/49)
@@ -21,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New Check:** `ckia:aws:cost:UnderutilizedEBSVolumes` [#9](https://github.com/brittandeyoung/ckia/issues/9)
 - **New Check:** `ckia:aws:cost:IdleDBInstance`
 
-[Unreleased]: https://github.com/brittandeyoung/ckia/compare/v0.1.0..HEAD
+[Unreleased]: https://github.com/brittandeyoung/ckia/compare/v0.2.0..HEAD
+[0.2.0]: https://github.com/brittandeyoung/ckia/compare/v0.1.0..v0.2.0
 [0.1.0]: https://github.com/brittandeyoung/ckia/compare/v0.0.1..v0.1.0
 [0.0.1]: https://github.com/brittandeyoung/ckia/tree/v0.0.1

--- a/cmd/aws/check.go
+++ b/cmd/aws/check.go
@@ -3,7 +3,9 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io/ioutil"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/config"
@@ -27,6 +29,8 @@ type Checks struct {
 
 var includeChecks []string
 var excludeChecks []string
+var outFile string
+var outFormat string
 
 // checkCmd represents the check command
 var checkCmd = &cobra.Command{
@@ -34,6 +38,11 @@ var checkCmd = &cobra.Command{
 	Short: "Run available checks for aws",
 	Long:  `Run available opinionated checks for aws cloud.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		// Validate flags
+		if !common.StringSliceContains([]string{"json"}, outFormat) {
+			return errors.New("unsupported format provided to out-format flag")
+		}
+
 		ctx := context.Background()
 		cfg, err := config.LoadDefaultConfig(ctx)
 		if err != nil {
@@ -100,7 +109,17 @@ var checkCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Println(resp)
+
+		if outFile != "" {
+			err = ioutil.WriteFile(outFile, json, 0644)
+
+			if err != nil {
+				return err
+			}
+		} else {
+			fmt.Println(resp)
+		}
+
 		return nil
 	},
 }
@@ -109,4 +128,6 @@ func init() {
 	cmd.AwsCmd.AddCommand(checkCmd)
 	checkCmd.Flags().StringSliceVarP(&includeChecks, "include-checks", "i", []string{}, "A list of all the checks you wish to run.")
 	checkCmd.Flags().StringSliceVarP(&excludeChecks, "exclude-checks", "e", []string{}, "A list of checks to exclude from running.")
+	checkCmd.Flags().StringVarP(&outFile, "out-file", "o", "", "A path to a file to store check results.")
+	checkCmd.Flags().StringVarP(&outFormat, "out-format", "f", "json", "The file output format for check results. Default: json (currently only json is supported).")
 }


### PR DESCRIPTION
### Description
<!---
Please provide a helpful description of what change this pull request will introduce.
--->

This PR adds two flags:

`out-file` : allows specifying the file to save the results to.
`out-format` : Allows specifying the format of the results. Currently json is still the only supported format. 

### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #67

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Running New Feature
<!--
When introducing a new check or behavior, it should be tested in a cloud account and have the results posted on this Pull request. 
-->

```
➜ ckia (main) ✗ go run main.go aws check --out-file results.json
Running [5] ckia Checks... 100% [====================================================================================] (5/5) [6s]   

...
```